### PR TITLE
fixed heraldEscalate check notificationId

### DIFF
--- a/server/escalate.js
+++ b/server/escalate.js
@@ -33,8 +33,8 @@ Meteor.methods({
    * @param {string} medium
    */
   heraldEscalate: function (notificationId, medium) {
-    check(notificationId, Meteor.Collection.ObjectID)
-    check(medium, String)
+    check(notificationId, String);
+    check(medium, String);
     try {
       Herald.escalate(notificationId, medium);
     } catch (e) {
@@ -73,6 +73,6 @@ Herald.escalate = function (notificationId, medium) {
   } else {
     var query = Herald._setProperty('media.' + medium + '.send', false);
   }
-  
+
   Herald.collection.update(notification._id, { $set: query } );
 };


### PR DESCRIPTION
I just changed check(notificationId, Meteor.Collection.ObjectID) to check(notificationId, String). Fixed a blocking issue when sending email. 